### PR TITLE
IconHelper leaves unsed API allocated memory

### DIFF
--- a/KeeAnywhere/IconHelper.cs
+++ b/KeeAnywhere/IconHelper.cs
@@ -180,6 +180,12 @@ namespace KeeAnywhere
             int cbFileInfo,
             FileInfoFlags uFlags);
 
+        //TODO: Required to introduce DestroyIcon see comments on ExtractIconEx under "Remarks"!
+        // [MSDN - ExtractIconEx]
+        // https://msdn.microsoft.com/de-de/library/windows/desktop/ms648069.aspx
+        // [MSDN - DestroyIcon]
+        // https://msdn.microsoft.com/de-de/library/windows/desktop/ms648069.aspx#Remarks
+        
         #endregion
 
         /// <summary>


### PR DESCRIPTION
Your working with the Windows API is dirty. You don't frees API allocated memory. In description of ExtractIconEx states under "Remarks" you have to destroy the icons, that means calling DestroyIcon for each icon handle (your IntPtr's).

I'm not familiar right now with GIT so I don't fix it in code, but introduces a "TODO" comment with links to the MSDN descriptions of both functions.