### PR TITLE
Get Google Drive OAuth token from response Uri instead of documentTitle.

### DIFF
--- a/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageConfigurator.cs
+++ b/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageConfigurator.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Google.Apis.Auth.OAuth2;
-using Google.Apis.Auth.OAuth2.Flows;
 using Google.Apis.Auth.OAuth2.Responses;
-using Google.Apis.Drive.v3;
-using Google.Apis.Services;
 using KeeAnywhere.Configuration;
 using KeeAnywhere.OAuth2;
 
@@ -49,12 +47,16 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
 
         public async Task<bool> Claim(Uri uri, string documentTitle)
         {
-            var parts = documentTitle.Split(' ');
+            var parts = HttpUtility.ParseQueryString(uri.Query);
 
-            if (parts.Length < 1 || parts[0] != "Success")
+            if (parts.Count < 1 || parts.Get("response") == null)
                 return false;
 
-            var code = parts[1].Split('=')[1];
+            var code = parts.Get("response");
+            if (!code.Contains("code"))
+                return false;
+
+            code = code.Split('=')[1];
 
             try
             {


### PR DESCRIPTION
When trying to add a Google Drive provider, issue #74 occurs, claiming authentication failed.

After debugging it turns out the documentTitle is an empty string, so the code cannot be retrieved from it. The code is however also present in the uri.

Extract the code from the uri and continue.