### PR TITLE
Correctly apply "no proxy" setting.

### DIFF
--- a/KeeAnywhere/StorageProviders/ProxyTools.cs
+++ b/KeeAnywhere/StorageProviders/ProxyTools.cs
@@ -32,7 +32,11 @@ namespace KeeAnywhere.StorageProviders
         public static void ApplyProxy(this HttpClientHandler handler)
         {
             var proxy = GetProxy();
-            if (proxy == null) return;
+            if (proxy == null)
+            {
+                handler.UseProxy = false;
+                return;
+            }
 
             handler.UseProxy = true;
             handler.Proxy = proxy;


### PR DESCRIPTION
Fixes #123.

Copied from issue comment:

[`UseProxy`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler.useproxy) *defaults* to `true`, and KeeAnywhere never explicitly sets it to `false` when there's no proxy defined:

https://github.com/Kyrodan/KeeAnywhere/blob/1ae5539bfa9ddde0906c1296393a61f9a8df2604/KeeAnywhere/StorageProviders/ProxyTools.cs#L32-L39

With the defaults of `UseProxy = true, Proxy = null`, HttpClientHandler falls back to using the system default ... despite the explicit setting of "No proxy" in KeePass.