### PR TITLE
Added support for OneDrive shared folders.

### DIFF
--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveApiExtensions.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveApiExtensions.cs
@@ -1,17 +1,67 @@
 using Microsoft.Graph;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace KeeAnywhere.StorageProviders.OneDrive
 {
     public static class OneDriveApiExtensions
     {
-        public static bool IsFolder(this DriveItem item)
+
+        /// <summary>
+        /// Configures a Graph API request for an object identified by the
+        /// item identifier stored in a StorageProviderItem object.
+        /// </summary>
+        /// <param name="api">A Graph API request builder.</param>
+        /// <param name="itemId">
+        /// The item ID from a StorageProviderItem object that was created
+        /// by the OneDrive storage provider.
+        /// </param>
+        /// <returns></returns>
+        public static IDriveItemRequestBuilder DriveItemFromStorageProviderItemId(this IGraphServiceClient api, string itemId)
         {
-            return item.Folder != null;
+            // ID must include a drive id prefix. 
+            // See also OneDriveStorageProvider.MakeStorageProviderItemId.
+            var idParts = itemId.Split('/');
+            if (idParts.Length != 2) throw new ArgumentOutOfRangeException("itemId");
+            return api.Drives[idParts[0]].Items[idParts[1]];
         }
 
-        public static bool IsFile(this DriveItem item)
+        /// <summary>
+        /// Configures a Graph API request for a OneDrive drive based on a 
+        /// path from a user's default drive. Accommodates top-level folders 
+        /// which are links to remote, shared items. 
+        /// </summary>
+        /// <param name="api">A Graph API request builder.</param>
+        /// <param name="path">
+        /// A URI path relative to the user's default drive.
+        /// </param>
+        /// <returns>
+        /// A task that yields a drive item request builder.
+        /// </returns>
+        /// <remarks>
+        /// An extra Web request has to be made to determine if the top 
+        /// folder is remote or local. That's why this method is async.
+        /// </remarks>
+        public async static Task<IDriveItemRequestBuilder> DriveItemFromPathAsync(this IGraphServiceClient api, string path)
         {
-            return item.File != null;
+            // The top folder could be a shared folder, in which case it's 
+            // on a different drive than the default. The path will use the
+            // name of the link in the user's root, which may be different
+            // from its actual (remote) name.
+            if (string.IsNullOrEmpty(path)) throw new ArgumentOutOfRangeException("path");
+            var parts = path.Split('/');
+            if (parts.Length == 1)
+                return api.Drive.Root.ItemWithPath(parts[0]);
+
+            var topFolder = await api.Drive.Root.ItemWithPath(Uri.EscapeDataString(parts[0])).Request().GetAsync();
+            var driveId = topFolder.RemoteItem == null ? topFolder.ParentReference.DriveId : topFolder.RemoteItem.ParentReference.DriveId;
+            var topFolderId = topFolder.RemoteItem == null ? topFolder.Id : topFolder.RemoteItem.Id;
+            // The top folder's apparent name can be different from its 
+            // actual name, so don't use the name as part of the path at all.
+            // We have the id, so navigate from there instead.
+            return api.Drives[driveId].Items[topFolderId].ItemWithPath(Uri.EscapeDataString(string.Join("/",parts.Skip(1))));
         }
+
     }
 }

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveHelper.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveHelper.cs
@@ -45,7 +45,7 @@ namespace KeeAnywhere.StorageProviders.OneDrive
             };
         }
 
-        public static async Task<IGraphServiceClient> GetApi(AccountConfiguration account)
+        public static IGraphServiceClient GetApi(AccountConfiguration account)
         {
             if (Cache.ContainsKey(account.Id)) return Cache[account.Id];
 


### PR DESCRIPTION
Addresses issue #134.

This adds support for shared folders which a user has "added
to their OneDrive". Such folders appear as, effectively, symbolic
links in the user's default root folder. These changes do not
provide a way to access other OneDrive items that have been
shared with the user.
