### PR TITLE
Changed OidcBrowser url from 127.0.0.1 to localhost. Fixes #301.

### DIFF
--- a/KeeAnywhere/OAuth2/OidcSystemBrowser.cs
+++ b/KeeAnywhere/OAuth2/OidcSystemBrowser.cs
@@ -35,20 +35,24 @@ namespace KeeAnywhere.OAuth2
                 ports = Enumerable.Range(49215, 16321);
             }
 
+            string[] hosts = { "127.0.0.1", "localhost" };
             foreach (var port in ports)
             {
-                redirectUri = CreateRedirectUri(port);
-                listener = new HttpListener();
-                listener.Prefixes.Add(redirectUri);
-                try
+                foreach (var host in hosts)
                 {
-                    listener.Start();
+                    redirectUri = CreateRedirectUri(host, port);
+                    listener = new HttpListener();
+                    listener.Prefixes.Add(redirectUri);
+                    try
+                    {
+                        listener.Start();
 
-                    return true;
-                }
-                catch
-                {
-                    // nothing to do here -- the listener disposes itself when Start throws
+                        return true;
+                    }
+                    catch
+                    {
+                        // nothing to do here -- the listener disposes itself when Start throws
+                    }
                 }
             }
 
@@ -58,9 +62,9 @@ namespace KeeAnywhere.OAuth2
             return false;
         }
 
-        private static string CreateRedirectUri(int port)
+        private static string CreateRedirectUri(string host, int port)
         {
-            return "http://localhost:" + port + "/";
+            return "http://" + host + ":" + port + "/";
         }
 
         public string RedirectUri

--- a/KeeAnywhere/OAuth2/OidcSystemBrowser.cs
+++ b/KeeAnywhere/OAuth2/OidcSystemBrowser.cs
@@ -60,7 +60,7 @@ namespace KeeAnywhere.OAuth2
 
         private static string CreateRedirectUri(int port)
         {
-            return "http://127.0.0.1:" + port + "/";
+            return "http://localhost:" + port + "/";
         }
 
         public string RedirectUri


### PR DESCRIPTION
Fix #301 affecting pre-Windows 10 devices. I know Windows 7 is out-of-support, but in this case the fix is trivial.

Changes the redirect URL for Oidc to use 'localhost' instead of '127.0.0.1'.
Windows seems to block opening the port prior to Windows 10 if it uses anything other than localhost.

I've tested on two machines, one with Win7 and the other with Win10.