### PR TITLE
Fix Google Drive Remote Backups not working in the root directory. Fixes #327.

### DIFF
--- a/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveHelper.cs
+++ b/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveHelper.cs
@@ -88,6 +88,7 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
 
         public static async Task<File> GetFileByPath(this DriveService api, string path)
         {
+            if (path == "" ) return await api.Files.Get("root").ExecuteAsync();
             var parts = path.Split('/');
             File file = null;
 


### PR DESCRIPTION
Fix #327 