### PR TITLE
Fix backups not working in the root directory. Fixes #327.

### DIFF
--- a/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageProvider.cs
+++ b/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageProvider.cs
@@ -92,7 +92,8 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
             var destFolder = CloudPath.GetDirectoryName(destPath);
             var destFile = new File
             {
-                Name = destFilename
+                Name = destFilename,
+                Parents = new[] { "root" }
             };
 
             if (!string.IsNullOrEmpty(destFolder))


### PR DESCRIPTION
Whenever GoogleDriveStorageProvider receives the empty string as a path argument, it will now treat it as a synonymn for "root" instead of passing it through to the API. Note, the paths "/", "//", "///", and so on are equally invalid and should probably be treated similarly, but that is not addressed here.

Fixes #327.
Maybe helps with #167 and part of #228.
I suspect #296 might benefit from a similar approach, because I ran into the "[multiple backup files being created before giving an error](https://github.com/Kyrodan/KeeAnywhere/issues/296#issuecomment-858831655)" issue with Google Drive at one point while working on this.

This is an alternative approach to my previous abandoned PR #375. I thought this might be cleaner, but maybe the one-liner there is better. You pick. I don't know the project well enough to say which one is cleaner. 