### PR TITLE
Gdrive shortcuts

### DIFF
--- a/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveHelper.cs
+++ b/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveHelper.cs
@@ -110,7 +110,7 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
 						if (file.ShortcutDetails == null)
 						{
 							var fileQuery = api.Files.Get(file.Id);
-							fileQuery.Fields = "*";
+							fileQuery.Fields = "shortcutDetails";
 							file = await fileQuery.ExecuteAsync();
 						}
 						file = await api.Files.Get(file.ShortcutDetails.TargetId).ExecuteAsync();

--- a/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveHelper.cs
+++ b/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveHelper.cs
@@ -102,6 +102,16 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
 
                 file = result.Files.FirstOrDefault();
                 if (file == null) return null;
+                if (file.MimeType == "application/vnd.google-apps.shortcut")
+                {
+                    if (file.ShortcutDetails == null)
+                    {
+                        var fileQuery = api.Files.Get(file.Id);
+                        fileQuery.Fields = "*";
+                        file = await fileQuery.ExecuteAsync();
+                    }
+                    file = await api.Files.Get(file.ShortcutDetails.TargetId).ExecuteAsync();
+                }
             }
 
             return file;

--- a/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageProvider.cs
+++ b/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageProvider.cs
@@ -129,7 +129,7 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
             var api = await GetApi();
             var query = api.Files.List();
             query.Q = string.Format("'{0}' in parents and trashed = false", parent.Id);
-            query.Fields = "files(id, name, mimeType, modifiedTime, shortcutDetails, parents)";
+            query.Fields = "nextPageToken, files(id, name, mimeType, shortcutDetails, modifiedTime, parents)"; //The shortcutDetails field isn't returned in queries by default. Unless we request it, it's always null. The downside is, now we have to spell out every field we *do* want. Forgetting something we need will mean it's always set to null in the returned query, File object, etc. and things will break. This already happened once when I forgot I needed to explicitly request nextPageToken.
 
             var items = await query.ExecuteAsync();
             var newItems = items.Files.Select(async _ => 
@@ -160,7 +160,7 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
             var api = await GetApi();
             var item = await api.GetFileByPath(path, true);
             if (item == null)
-                throw new FileNotFoundException("Goolge Drive: File not found.", path);
+                throw new FileNotFoundException("Google Drive: File not found.", path);
 
             return await GetChildrenByParentItem(new StorageProviderItem {Id = item.Id});
         }

--- a/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageProvider.cs
+++ b/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageProvider.cs
@@ -26,7 +26,7 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
         {
             var api = await GetApi();
 
-            var file = await api.GetFileByPath(path);
+            var file = await api.GetFileByPath(path, true);
             if (file == null)
                 return null;
 
@@ -48,7 +48,7 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
 
             IUploadProgress progress;
 
-            var file = await api.GetFileByPath(path);
+            var file = await api.GetFileByPath(path, true);
             if (file != null)
             {
                 progress = await api.Files.Update(null, file.Id, stream, "application/octet-stream").UploadAsync();
@@ -66,7 +66,7 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
 
                 if (!string.IsNullOrEmpty(folderName))
                 {
-                    var folder = await api.GetFileByPath(folderName);
+                    var folder = await api.GetFileByPath(folderName, true);
                     if (folder == null)
                         throw new InvalidOperationException(string.Format("Folder does not exist: {0}", folderName));
 
@@ -84,12 +84,12 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
         {
             var api = await GetApi();
 
-            var sourceFile = await api.GetFileByPath(sourcePath);
+            var sourceFile = await api.GetFileByPath(sourcePath, true);
             if (sourceFile == null)
                 throw new FileNotFoundException("Google Drive: File not found.", sourcePath);
 
             var destFolder = CloudPath.GetDirectoryName(destPath);
-            var parentFolder = await api.GetFileByPath(destFolder);
+            var parentFolder = await api.GetFileByPath(destFolder, true);
             if (parentFolder == null)
                 throw new FileNotFoundException("Google Drive: File not found.", destFolder);
 
@@ -107,7 +107,7 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
         {
             var api = await GetApi();
 
-            var file = await api.GetFileByPath(path);
+            var file = await api.GetFileByPath(path, false);
             if (file == null)
                 throw new FileNotFoundException("Goolge Drive: File not found.", path);
 
@@ -178,7 +178,7 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
         public async Task<IEnumerable<StorageProviderItem>> GetChildrenByParentPath(string path)
         {
             var api = await GetApi();
-            var item = await api.GetFileByPath(path);
+            var item = await api.GetFileByPath(path, true);
             if (item == null)
                 throw new FileNotFoundException("Goolge Drive: File not found.", path);
 


### PR DESCRIPTION
### This PR implements shortcuts for Google Drive.

Both shortcuts to files and shortcuts to folders are supported. Multiple folder-shortcuts in a path are supported. The target files and folders can be on your own drive or under "shared with me", but Shared Drive support (a GSuite feature) is another matter.

Fixes #223, #232, #310, #337, #339, and #356. Or at least provides a workaround.
With shortcuts, users will now be have a way to access shared files, which I know is very useful for users like me who want to share databases! We can create a shortcut to the shared file or folder in our own drive and access the file(s) that way.

### Method and Rationale
This PR first adds the ability to recognize shortcuts by their unique mime type, "application/vnd.google-apps.shortcut".

Next, when parsing the Google Drive tree for the "Open from Cloud" dialog, I treat shortcuts specially: a shortcut returns the data for its target instead of itself. Basically, the rest of KeeAnywhere has no idea shortcuts even exist. The Google Drive layer pretends that the files were directly included in that directory, kind of like hard links. I understand this is similar to the original structure Google Drive used, which shortcuts were introduced to replace.

Finally, load, save, copy, and delete are modified to also transparently follow shortcuts anywhere in the URL path. Again, this presents a view of the tree rather like hard-links in UNIX.  (Technically, this change is implemented in the GetFileByPath routine that all four rely on)

### Caveats
There is one exception. Delete *will* delete the shortcut itself if the shortcut is the last item in the path. Why? Think what would happen if I tried to delete `My Drive/foo.kdbx`. If we delete the underlying file then `My Drive/foo.kdbx` won't be deleted at all, because it represents the shortcut. In fact, it will stay there forever! But some other file like `My Drive/this/is/some/buried/folder/foo.kdbx` would disappear instead! This would not be the expected behavior at all! For now, I think it's a moot point. I see delete is only called by the remote backup routine. The URLs it passes always point to real files, previously created by the backup function. But if delete ever becomes used more widely, we'll be ready to do it right.
Also, because shortcuts are exposed as "hard-link" style items, there's no way to know from the interface if something is a shortcut or not. They look the same as "real" files and folders. I think this is not so bad for now, because at least it works now and also that's how it used to be before Google started changing everything over to shortcuts.

### Conclusion and Help Needed
A lot of time and effort went into this PR for me, because I am not used to .NET or C#. But I really love using this plugin and want to help!
I would really appreciate someone looking over this to see if it makes sense or if I missed a better way to do things. This is a bigger change than I have made so far. It involved some tricky stuff I'm not sure I got right, particularly with the asynchronous programming stuff and the Select calls in GetChildrenByParentPath.