### PR TITLE
Fix to connect Amazon S3 compatible endpoints with custom auth region

### DIFF
--- a/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3AccountForm.Designer.cs
+++ b/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3AccountForm.Designer.cs
@@ -41,10 +41,12 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             this.m_txtSessionToken = new System.Windows.Forms.TextBox();
             this.m_chkUseSessionToken = new System.Windows.Forms.CheckBox();
             this.m_grpEndpoint = new System.Windows.Forms.GroupBox();
+            this.m_authRegion = new System.Windows.Forms.TextBox();
             this.m_cmbEndpointUrl = new System.Windows.Forms.ComboBox();
             this.m_rbTypeOther = new System.Windows.Forms.RadioButton();
             this.m_rbTypeAmazon = new System.Windows.Forms.RadioButton();
             this.m_grpCredentials = new System.Windows.Forms.GroupBox();
+            this.m_lblAuthRegion = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.m_bannerImage)).BeginInit();
             this.m_grpEndpoint.SuspendLayout();
             this.m_grpCredentials.SuspendLayout();
@@ -62,7 +64,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             // m_btnOK
             // 
             this.m_btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.m_btnOK.Location = new System.Drawing.Point(285, 301);
+            this.m_btnOK.Location = new System.Drawing.Point(285, 349);
             this.m_btnOK.Name = "m_btnOK";
             this.m_btnOK.Size = new System.Drawing.Size(75, 23);
             this.m_btnOK.TabIndex = 7;
@@ -74,7 +76,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             // 
             this.m_btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.m_btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.m_btnCancel.Location = new System.Drawing.Point(366, 301);
+            this.m_btnCancel.Location = new System.Drawing.Point(366, 349);
             this.m_btnCancel.Name = "m_btnCancel";
             this.m_btnCancel.Size = new System.Drawing.Size(75, 23);
             this.m_btnCancel.TabIndex = 8;
@@ -136,7 +138,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             // m_btnTest
             // 
             this.m_btnTest.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.m_btnTest.Location = new System.Drawing.Point(12, 301);
+            this.m_btnTest.Location = new System.Drawing.Point(12, 349);
             this.m_btnTest.Name = "m_btnTest";
             this.m_btnTest.Size = new System.Drawing.Size(75, 23);
             this.m_btnTest.TabIndex = 6;
@@ -148,7 +150,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             // 
             this.m_lblTestResult.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.m_lblTestResult.Location = new System.Drawing.Point(12, 251);
+            this.m_lblTestResult.Location = new System.Drawing.Point(12, 299);
             this.m_lblTestResult.Name = "m_lblTestResult";
             this.m_lblTestResult.Size = new System.Drawing.Size(429, 45);
             this.m_lblTestResult.TabIndex = 9;
@@ -183,6 +185,8 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             // 
             this.m_grpEndpoint.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.m_grpEndpoint.Controls.Add(this.m_lblAuthRegion);
+            this.m_grpEndpoint.Controls.Add(this.m_authRegion);
             this.m_grpEndpoint.Controls.Add(this.m_cmbEndpointUrl);
             this.m_grpEndpoint.Controls.Add(this.m_rbTypeOther);
             this.m_grpEndpoint.Controls.Add(this.m_rbTypeAmazon);
@@ -190,10 +194,20 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             this.m_grpEndpoint.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.m_grpEndpoint.Location = new System.Drawing.Point(12, 172);
             this.m_grpEndpoint.Name = "m_grpEndpoint";
-            this.m_grpEndpoint.Size = new System.Drawing.Size(429, 76);
+            this.m_grpEndpoint.Size = new System.Drawing.Size(429, 107);
             this.m_grpEndpoint.TabIndex = 18;
             this.m_grpEndpoint.TabStop = false;
             this.m_grpEndpoint.Text = "Endpoint";
+            // 
+            // m_authRegion
+            // 
+            this.m_authRegion.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.m_authRegion.Enabled = false;
+            this.m_authRegion.Location = new System.Drawing.Point(158, 72);
+            this.m_authRegion.Name = "m_authRegion";
+            this.m_authRegion.Size = new System.Drawing.Size(265, 20);
+            this.m_authRegion.TabIndex = 15;
             // 
             // m_cmbEndpointUrl
             // 
@@ -209,8 +223,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             "https://s3.us-central-1.wasabisys.com",
             "https://s3.us-west-1.wasabisys.com",
             "https://s3.eu-central-1.wasabisys.com",
-            "https://s3.ap-northeast-1.wasabisys.com"
-            });
+            "https://s3.ap-northeast-1.wasabisys.com"});
             this.m_cmbEndpointUrl.Location = new System.Drawing.Point(158, 45);
             this.m_cmbEndpointUrl.Name = "m_cmbEndpointUrl";
             this.m_cmbEndpointUrl.Size = new System.Drawing.Size(265, 21);
@@ -261,13 +274,23 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             this.m_grpCredentials.TabStop = false;
             this.m_grpCredentials.Text = "Credentials";
             // 
+            // m_lblAuthRegion
+            // 
+            this.m_lblAuthRegion.AutoSize = true;
+            this.m_lblAuthRegion.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.m_lblAuthRegion.Location = new System.Drawing.Point(75, 75);
+            this.m_lblAuthRegion.Name = "m_lblAuthRegion";
+            this.m_lblAuthRegion.Size = new System.Drawing.Size(77, 13);
+            this.m_lblAuthRegion.TabIndex = 15;
+            this.m_lblAuthRegion.Text = "Auth Region";
+            // 
             // AmazonS3AccountForm
             // 
             this.AcceptButton = this.m_btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.m_btnCancel;
-            this.ClientSize = new System.Drawing.Size(453, 336);
+            this.ClientSize = new System.Drawing.Size(453, 384);
             this.Controls.Add(this.m_grpCredentials);
             this.Controls.Add(this.m_grpEndpoint);
             this.Controls.Add(this.m_lblTestResult);
@@ -312,5 +335,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
         private System.Windows.Forms.RadioButton m_rbTypeAmazon;
         private System.Windows.Forms.ComboBox m_cmbEndpointUrl;
         private System.Windows.Forms.GroupBox m_grpCredentials;
+        private System.Windows.Forms.TextBox m_authRegion;
+        private System.Windows.Forms.Label m_lblAuthRegion;
     }
 }

--- a/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3AccountForm.Designer.cs
+++ b/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3AccountForm.Designer.cs
@@ -42,11 +42,11 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             this.m_chkUseSessionToken = new System.Windows.Forms.CheckBox();
             this.m_grpEndpoint = new System.Windows.Forms.GroupBox();
             this.m_authRegion = new System.Windows.Forms.TextBox();
+            this.m_lblAuthRegion = new System.Windows.Forms.Label();
             this.m_cmbEndpointUrl = new System.Windows.Forms.ComboBox();
             this.m_rbTypeOther = new System.Windows.Forms.RadioButton();
             this.m_rbTypeAmazon = new System.Windows.Forms.RadioButton();
             this.m_grpCredentials = new System.Windows.Forms.GroupBox();
-            this.m_lblAuthRegion = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.m_bannerImage)).BeginInit();
             this.m_grpEndpoint.SuspendLayout();
             this.m_grpCredentials.SuspendLayout();
@@ -185,8 +185,8 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             // 
             this.m_grpEndpoint.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.m_grpEndpoint.Controls.Add(this.m_lblAuthRegion);
             this.m_grpEndpoint.Controls.Add(this.m_authRegion);
+            this.m_grpEndpoint.Controls.Add(this.m_lblAuthRegion);
             this.m_grpEndpoint.Controls.Add(this.m_cmbEndpointUrl);
             this.m_grpEndpoint.Controls.Add(this.m_rbTypeOther);
             this.m_grpEndpoint.Controls.Add(this.m_rbTypeAmazon);
@@ -194,7 +194,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             this.m_grpEndpoint.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.m_grpEndpoint.Location = new System.Drawing.Point(12, 172);
             this.m_grpEndpoint.Name = "m_grpEndpoint";
-            this.m_grpEndpoint.Size = new System.Drawing.Size(429, 107);
+            this.m_grpEndpoint.Size = new System.Drawing.Size(429, 124);
             this.m_grpEndpoint.TabIndex = 18;
             this.m_grpEndpoint.TabStop = false;
             this.m_grpEndpoint.Text = "Endpoint";
@@ -208,6 +208,17 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             this.m_authRegion.Name = "m_authRegion";
             this.m_authRegion.Size = new System.Drawing.Size(265, 20);
             this.m_authRegion.TabIndex = 15;
+            this.m_authRegion.TextChanged += new System.EventHandler(this.OnTextChanged);
+            // 
+            // m_lblAuthRegion
+            // 
+            this.m_lblAuthRegion.AutoSize = true;
+            this.m_lblAuthRegion.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.m_lblAuthRegion.Location = new System.Drawing.Point(23, 75);
+            this.m_lblAuthRegion.Name = "m_lblAuthRegion";
+            this.m_lblAuthRegion.Size = new System.Drawing.Size(129, 26);
+            this.m_lblAuthRegion.TabIndex = 15;
+            this.m_lblAuthRegion.Text = "Override Auth Region\r\n(optional)";
             // 
             // m_cmbEndpointUrl
             // 
@@ -273,16 +284,6 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             this.m_grpCredentials.TabIndex = 19;
             this.m_grpCredentials.TabStop = false;
             this.m_grpCredentials.Text = "Credentials";
-            // 
-            // m_lblAuthRegion
-            // 
-            this.m_lblAuthRegion.AutoSize = true;
-            this.m_lblAuthRegion.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.m_lblAuthRegion.Location = new System.Drawing.Point(75, 75);
-            this.m_lblAuthRegion.Name = "m_lblAuthRegion";
-            this.m_lblAuthRegion.Size = new System.Drawing.Size(77, 13);
-            this.m_lblAuthRegion.TabIndex = 15;
-            this.m_lblAuthRegion.Text = "Auth Region";
             // 
             // AmazonS3AccountForm
             // 

--- a/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3AccountForm.cs
+++ b/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3AccountForm.cs
@@ -80,7 +80,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             
             try
             {
-                var config = this.IsAmazon ? AmazonS3Helper.GetConfig(this.AWSRegion) : AmazonS3Helper.GetConfig(this.EndpointUrl);
+                var config = this.IsAmazon ? AmazonS3Helper.GetConfig(this.AWSRegion) : AmazonS3Helper.GetConfig(this.EndpointUrl, authRegion: this.OverridedAuthRegion);
 
                 using (var api = AmazonS3Helper.GetApi(credentials, config))
                 {
@@ -112,7 +112,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
         public string AccessKey { get { return m_txtAccessKey.Text.Trim(); } }
         public string SecretKey { get { return m_txtSecretKey.Text.Trim(); } }
         public string SessionToken { get { return m_txtSessionToken.Text.Trim(); } }
-        public string AuthRegion { get { return m_authRegion.Text.Trim();  } }
+        public string OverridedAuthRegion { get { return m_authRegion.Text.Trim();  } }
         public bool UseSessionToken { get { return m_chkUseSessionToken.Checked; } }
         public RegionEndpoint AWSRegion { get { return (RegionEndpoint) m_cmbRegion.SelectedItem; } }
         public string EndpointUrl { get { return m_cmbEndpointUrl.Text.Trim(); } }

--- a/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3AccountForm.cs
+++ b/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3AccountForm.cs
@@ -112,6 +112,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
         public string AccessKey { get { return m_txtAccessKey.Text.Trim(); } }
         public string SecretKey { get { return m_txtSecretKey.Text.Trim(); } }
         public string SessionToken { get { return m_txtSessionToken.Text.Trim(); } }
+        public string AuthRegion { get { return m_authRegion.Text.Trim();  } }
         public bool UseSessionToken { get { return m_chkUseSessionToken.Checked; } }
         public RegionEndpoint AWSRegion { get { return (RegionEndpoint) m_cmbRegion.SelectedItem; } }
         public string EndpointUrl { get { return m_cmbEndpointUrl.Text.Trim(); } }
@@ -152,6 +153,8 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
         {
             m_cmbRegion.Enabled = m_rbTypeAmazon.Checked;
             m_cmbEndpointUrl.Enabled = m_rbTypeOther.Checked;
+            m_authRegion.Enabled = m_rbTypeOther.Checked;
+            m_lblAuthRegion.Enabled = m_rbTypeOther.Checked;
             ClearTestResult();
         }
     }

--- a/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3Helper.cs
+++ b/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3Helper.cs
@@ -54,7 +54,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
 
             var config = new AmazonS3Config
             {
-                RegionEndpoint = RegionEndpoint.USEast1, // Required???
+                //RegionEndpoint = RegionEndpoint.USEast1, // Required???
                 ServiceURL = endpointURL,
                 ForcePathStyle = true,
                 Timeout = Timeout.InfiniteTimeSpan

--- a/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3Helper.cs
+++ b/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3Helper.cs
@@ -31,7 +31,10 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             AmazonS3Config config;
 
             if (account.AdditionalSettings.ContainsKey("EndpointURL")) {
-                config = GetConfig(account.AdditionalSettings["EndpointURL"]);
+                config = GetConfig(
+                    account.AdditionalSettings["EndpointURL"],
+                    authRegion: account.AdditionalSettings["OverridedAuthRegion"]
+                );
             } else
             {
                 var region = RegionEndpoint.USWest1;
@@ -48,16 +51,16 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             return GetApi(credentials, config);
         }
 
-        public static AmazonS3Config GetConfig(string endpointURL)
+        public static AmazonS3Config GetConfig(string endpointURL, string authRegion = "")
         {
             if (string.IsNullOrEmpty(endpointURL)) throw new ArgumentNullException("endpointURL");
 
             var config = new AmazonS3Config
             {
-                //RegionEndpoint = RegionEndpoint.USEast1, // Required???
                 ServiceURL = endpointURL,
                 ForcePathStyle = true,
-                Timeout = Timeout.InfiniteTimeSpan
+                Timeout = Timeout.InfiniteTimeSpan,
+                AuthenticationRegion = String.IsNullOrWhiteSpace(authRegion) ? "" : authRegion
             };
 
             return config;

--- a/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3StorageConfigurator.cs
+++ b/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3StorageConfigurator.cs
@@ -34,7 +34,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             } else
             {
                 account.AdditionalSettings.Add("EndpointURL", dlg.EndpointUrl);
-                account.AdditionalSettings.Add("AuthRegion", dlg.AuthRegion);
+                account.AdditionalSettings.Add("OverridedAuthRegion", dlg.OverridedAuthRegion);
             }
 
             account.AdditionalSettings.Add("UseSessionToken", Convert.ToString(dlg.UseSessionToken));

--- a/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3StorageConfigurator.cs
+++ b/KeeAnywhere/StorageProviders/AmazonS3/AmazonS3StorageConfigurator.cs
@@ -34,6 +34,7 @@ namespace KeeAnywhere.StorageProviders.AmazonS3
             } else
             {
                 account.AdditionalSettings.Add("EndpointURL", dlg.EndpointUrl);
+                account.AdditionalSettings.Add("AuthRegion", dlg.AuthRegion);
             }
 
             account.AdditionalSettings.Add("UseSessionToken", Convert.ToString(dlg.UseSessionToken));


### PR DESCRIPTION
Hi,

I realised that it is not possible to connect to specific S3 compatible endpoints (such as those provided by [OVH](www.ovh.com)).

When trying to connect, you get the following error:
```
The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'xxx'
```
where 'xxx' is the name of the region for your S3 endpoint in ovh (for OVH, it can be "gra", "uk", ...). This issue also happened elsewhere see [here](https://forums.urbackup.org/t/cant-connect-to-s3-compatible-endpoints/9615).

I propose a solution similar to the one in the link. A new field 'Override Auth Region' is added below the Other URL field and is only typable when dealing with endpoints different from Amazon. When you type your region, it works as expected. If you type nothing, it should do nothing. 

As I don't own an S3 compatible bucket (non-Amazon and non OVH), I am not able to confirm that it didn't break the behavior for these.
I also don't know if the issue is specific to OVH.

Best regards.