### PR TITLE
Fix Dropbox remote backup failure when the database is saved to root directory

### DIFF
--- a/KeeAnywhere/StorageProviders/Dropbox/DropboxStorageProvider.cs
+++ b/KeeAnywhere/StorageProviders/Dropbox/DropboxStorageProvider.cs
@@ -111,8 +111,14 @@ namespace KeeAnywhere.StorageProviders.Dropbox
 
         private static string RootPath(string path)
         {
-            if (path[0] != CloudPath.DirectorySeparatorChar)
+            if (string.IsNullOrEmpty(path))
+            {
+                path = "";
+            }
+            else if (path[0] != CloudPath.DirectorySeparatorChar)
+            {
                 path = CloudPath.DirectorySeparatorChar + path;
+            }
 
             return path;
         }


### PR DESCRIPTION
This is a fix to #459 .