### PR TITLE
Fix issue 468 for OneDive/Box + improved Google drive behavior (surfacing errors)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
 .vs/
+.vscode/

--- a/KeeAnywhere/KeeAnywhereExt.cs
+++ b/KeeAnywhere/KeeAnywhereExt.cs
@@ -72,6 +72,9 @@ namespace KeeAnywhere
             _configService = new ConfigurationService(pluginHost);
             _configService.Load();
 
+            // Persist OneDrive refresh-token rotations as they happen.
+            StorageProviders.OneDrive.OneDriveHelper.OnAccountChanged = _ => _configService.Save();
+
             // Initialize CacheManager
             _cacheManagerService = new CacheManagerService(_configService, _host);
             _cacheManagerService.RegisterEvents();

--- a/KeeAnywhere/OAuth2/OidcSystemBrowser.cs
+++ b/KeeAnywhere/OAuth2/OidcSystemBrowser.cs
@@ -118,11 +118,7 @@ namespace KeeAnywhere.OAuth2
 
                     if (String.IsNullOrWhiteSpace(result))
                     {
-                        return new BrowserResult
-                        {
-                            ResultType = BrowserResultType.UnknownError,
-                            Error = "Empty response. " + context.Request.HttpMethod + " " + context.Request.Url
-                        };
+                        return new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = "Empty response." };
                     }
 
                     return new BrowserResult { Response = result, ResultType = BrowserResultType.Success };

--- a/KeeAnywhere/OAuth2/OidcSystemBrowser.cs
+++ b/KeeAnywhere/OAuth2/OidcSystemBrowser.cs
@@ -104,22 +104,25 @@ namespace KeeAnywhere.OAuth2
                     var context = await listener.GetContextAsync();
 
                     string result;
-
-                    //if (options.ResponseMode == IdentityModel.OidcClient.OidcClientOptions.AuthorizeResponseMode.Redirect)
-                    //{
+                    if (context.Request.HttpMethod == "POST" && context.Request.HasEntityBody)
+                    {
+                        result = ProcessFormPost(context.Request);
+                    }
+                    else
+                    {
                         result = context.Request.Url.Query;
-                    //}
-                    //else
-                    //{
-                    //    result = ProcessFormPost(context.Request);
-                    //}
+                    }
 
                     await SendResponse(context.Response);
 
 
                     if (String.IsNullOrWhiteSpace(result))
                     {
-                        return new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = "Empty response." };
+                        return new BrowserResult
+                        {
+                            ResultType = BrowserResultType.UnknownError,
+                            Error = "Empty response. " + context.Request.HttpMethod + " " + context.Request.Url
+                        };
                     }
 
                     return new BrowserResult { Response = result, ResultType = BrowserResultType.Success };

--- a/KeeAnywhere/StorageProviders/Box/BoxHelper.cs
+++ b/KeeAnywhere/StorageProviders/Box/BoxHelper.cs
@@ -57,6 +57,11 @@ namespace KeeAnywhere.StorageProviders.Box
             return client;
         }
 
+        public static void InvalidateCache(string accountId)
+        {
+            Cache.Remove(accountId);
+        }
+
         public static BoxClient GetClient()
         {
             return GetClient((OAuthSession)null);

--- a/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageProvider.cs
+++ b/KeeAnywhere/StorageProviders/GoogleDrive/GoogleDriveStorageProvider.cs
@@ -28,13 +28,13 @@ namespace KeeAnywhere.StorageProviders.GoogleDrive
 
             var file = await api.GetFileByPath(path, true);
             if (file == null)
-                return null;
+                throw new FileNotFoundException("Google Drive: File not found.", path);
 
             var stream = new MemoryStream();
             var progress = await api.Files.Get(file.Id).DownloadAsync(stream);
 
-            if (progress.Status != DownloadStatus.Completed || progress.Exception != null)
-                return null;
+            if (progress.Status != DownloadStatus.Completed)
+                throw new InvalidOperationException("Google Drive download failed: " + progress.Status, progress.Exception);
 
             stream.Seek(0, SeekOrigin.Begin);
 

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveApiExtensions.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveApiExtensions.cs
@@ -29,43 +29,45 @@ namespace KeeAnywhere.StorageProviders.OneDrive
         }
 
         /// <summary>
-        /// Configures a Graph API request for a OneDrive drive based on a 
-        /// path from a user's default drive. Accommodates top-level folders 
-        /// which are links to remote, shared items. 
+        /// Resolves a path under the user's default drive (or a remote
+        /// shared mount) to an Items[id] request builder.
         /// </summary>
-        /// <param name="api">A Graph API request builder.</param>
-        /// <param name="path">
-        /// A URI path relative to the user's default drive.
-        /// </param>
-        /// <returns>
-        /// A task that yields a drive item request builder.
-        /// </returns>
         /// <remarks>
-        /// An extra Web request has to be made to determine if the top 
-        /// folder is remote or local. That's why this method is async.
+        /// Personal OneDrive does not reliably honor path-based item URLs
+        /// for content operations: the /:/path:/ form 404s on download, and
+        /// the itemWithPath(path='...') function form URL-encodes '/' as
+        /// %2F which Graph treats as a literal name. We walk the path one
+        /// segment at a time via Children listings so callers always get a
+        /// /drives/{drive}/items/{id} URL.
         /// </remarks>
         public async static Task<DriveItemItemRequestBuilder> DriveItemFromPathAsync(this GraphServiceClient api, string path)
         {
-            // The top folder could be a shared folder, in which case it's 
-            // on a different drive than the default. The path will use the
-            // name of the link in the user's root, which may be different
-            // from its actual (remote) name.
             if (string.IsNullOrEmpty(path)) throw new ArgumentOutOfRangeException("path");
             var parts = path.Split('/');
-            var rootItem = await api.Me.Drive.GetAsync();
+            var drive = await api.Me.Drive.GetAsync();
 
-            if (parts.Length == 1)
+            var driveId = drive.Id;
+            var currentId = (await api.Drives[driveId].Root.GetAsync()).Id;
+
+            foreach (var segment in parts)
             {
-                return api.Drives[rootItem.Id].Root.ItemWithPath(parts[0]);
+                var children = await api.Drives[driveId].Items[currentId].Children.GetAsync();
+                var match = children.Value.FirstOrDefault(c => c.Name == segment);
+                if (match == null)
+                    throw new System.IO.FileNotFoundException("OneDrive: '" + segment + "' not found under '" + path + "'");
+
+                if (match.RemoteItem != null)
+                {
+                    driveId = match.RemoteItem.ParentReference.DriveId;
+                    currentId = match.RemoteItem.Id;
+                }
+                else
+                {
+                    currentId = match.Id;
+                }
             }
 
-            var topFolder = await api.Drives[rootItem.Id].Root.ItemWithPath(Uri.EscapeDataString(parts[0])).GetAsync();
-            var driveId = topFolder.RemoteItem == null ? topFolder.ParentReference.DriveId : topFolder.RemoteItem.ParentReference.DriveId;
-            var topFolderId = topFolder.RemoteItem == null ? topFolder.Id : topFolder.RemoteItem.Id;
-            // The top folder's apparent name can be different from its 
-            // actual name, so don't use the name as part of the path at all.
-            // We have the id, so navigate from there instead.
-            return api.Drives[driveId].Items[topFolderId].ItemWithPath(Uri.EscapeDataString(string.Join("/",parts.Skip(1))));
+            return api.Drives[driveId].Items[currentId];
         }
 
     }

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveApiExtensions.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveApiExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Graph;
 using Microsoft.Graph.Drives.Item.Items.Item;
+using Microsoft.Graph.Models;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -51,8 +52,7 @@ namespace KeeAnywhere.StorageProviders.OneDrive
 
             foreach (var segment in parts)
             {
-                var children = await api.Drives[driveId].Items[currentId].Children.GetAsync();
-                var match = children.Value.FirstOrDefault(c => c.Name == segment);
+                var match = await FindChildAsync(api, driveId, currentId, segment);
                 if (match == null)
                     throw new System.IO.FileNotFoundException("OneDrive: '" + segment + "' not found under '" + path + "'");
 
@@ -68,6 +68,23 @@ namespace KeeAnywhere.StorageProviders.OneDrive
             }
 
             return api.Drives[driveId].Items[currentId];
+        }
+
+        // Microsoft Graph paginates Children at 200 items per page by default.
+        // Walk pages until we find the named child or exhaust the listing.
+        private static async Task<DriveItem> FindChildAsync(GraphServiceClient api, string driveId, string parentId, string name)
+        {
+            var page = await api.Drives[driveId].Items[parentId].Children.GetAsync();
+            while (page != null)
+            {
+                var match = page.Value.FirstOrDefault(c => c.Name == name);
+                if (match != null) return match;
+                if (string.IsNullOrEmpty(page.OdataNextLink)) return null;
+                page = await api.Drives[driveId].Items[parentId].Children
+                    .WithUrl(page.OdataNextLink)
+                    .GetAsync();
+            }
+            return null;
         }
 
     }

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveAuthenticationProvider.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveAuthenticationProvider.cs
@@ -18,6 +18,7 @@ namespace KeeAnywhere.StorageProviders.OneDrive
         private readonly OidcFlow _flow;
         private readonly AccountConfiguration _account;
         private readonly Action<AccountConfiguration> _onAccountChanged;
+        // Serializes concurrent Graph requests so the refresh + rotation-persist runs once.
         private readonly SemaphoreSlim _refreshLock = new SemaphoreSlim(1, 1);
         private RefreshTokenResult _token;
 

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveAuthenticationProvider.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveAuthenticationProvider.cs
@@ -23,8 +23,6 @@ namespace KeeAnywhere.StorageProviders.OneDrive
 
         public OneDriveAuthenticationProvider(OidcFlow flow, AccountConfiguration account, Action<AccountConfiguration> onAccountChanged)
         {
-            if (flow == null) throw new ArgumentNullException("flow");
-            if (account == null) throw new ArgumentNullException("account");
             _flow = flow;
             _account = account;
             _onAccountChanged = onAccountChanged;
@@ -48,9 +46,7 @@ namespace KeeAnywhere.StorageProviders.OneDrive
                         throw new ServiceException(detail);
                     }
 
-                    // Microsoft rotates the refresh token on every refresh.
-                    // Persist the new one or the stored secret drifts and
-                    // eventually gets rejected as invalid_grant.
+                    // Microsoft rotates the refresh token on every refresh; persist it or the stored secret eventually drifts to invalid_grant.
                     if (!string.IsNullOrEmpty(token.RefreshToken) && token.RefreshToken != _account.Secret)
                     {
                         _account.Secret = token.RefreshToken;

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveAuthenticationProvider.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveAuthenticationProvider.cs
@@ -28,14 +28,15 @@ namespace KeeAnywhere.StorageProviders.OneDrive
         {
             var token = _token;
 
-            if (token == null || _token.IsError || _token.AccessTokenExpiration <= DateTime.Now)
+            if (token == null || token.IsError || token.AccessTokenExpiration <= DateTime.UtcNow)
             {
                 token = await _flow.RefreshTokenAsync(_refreshToken);
 
                 if (token.IsError)
                 {
                     _token = null;
-                    throw new ServiceException(token.Error);
+                    var detail = string.IsNullOrEmpty(token.ErrorDescription) ? token.Error : token.Error + ": " + token.ErrorDescription;
+                    throw new ServiceException(detail);
                 }
 
                 _token = token;

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveAuthenticationProvider.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveAuthenticationProvider.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using IdentityModel.OidcClient.Results;
+using KeeAnywhere.Configuration;
 using KeeAnywhere.OAuth2;
 using Microsoft.Graph;
 using Microsoft.Kiota.Abstractions;
@@ -14,38 +15,60 @@ namespace KeeAnywhere.StorageProviders.OneDrive
 {
     public class OneDriveAuthenticationProvider : IAuthenticationProvider
     {
-        private OidcFlow _flow;
-        private string _refreshToken;
+        private readonly OidcFlow _flow;
+        private readonly AccountConfiguration _account;
+        private readonly Action<AccountConfiguration> _onAccountChanged;
+        private readonly SemaphoreSlim _refreshLock = new SemaphoreSlim(1, 1);
         private RefreshTokenResult _token;
 
-        public OneDriveAuthenticationProvider(OidcFlow flow, string refreshToken)
+        public OneDriveAuthenticationProvider(OidcFlow flow, AccountConfiguration account, Action<AccountConfiguration> onAccountChanged)
         {
+            if (flow == null) throw new ArgumentNullException("flow");
+            if (account == null) throw new ArgumentNullException("account");
             _flow = flow;
-            _refreshToken = refreshToken;
+            _account = account;
+            _onAccountChanged = onAccountChanged;
         }
 
         public async Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object> additionalAuthenticationContext = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var token = _token;
-
-            if (token == null || token.IsError || token.AccessTokenExpiration <= DateTime.UtcNow)
+            await _refreshLock.WaitAsync(cancellationToken);
+            try
             {
-                token = await _flow.RefreshTokenAsync(_refreshToken);
+                var token = _token;
 
-                if (token.IsError)
+                if (token == null || token.IsError || token.AccessTokenExpiration <= DateTime.UtcNow)
                 {
-                    _token = null;
-                    var detail = string.IsNullOrEmpty(token.ErrorDescription) ? token.Error : token.Error + ": " + token.ErrorDescription;
-                    throw new ServiceException(detail);
+                    token = await _flow.RefreshTokenAsync(_account.Secret);
+
+                    if (token.IsError)
+                    {
+                        _token = null;
+                        var detail = string.IsNullOrEmpty(token.ErrorDescription) ? token.Error : token.Error + ": " + token.ErrorDescription;
+                        throw new ServiceException(detail);
+                    }
+
+                    // Microsoft rotates the refresh token on every refresh.
+                    // Persist the new one or the stored secret drifts and
+                    // eventually gets rejected as invalid_grant.
+                    if (!string.IsNullOrEmpty(token.RefreshToken) && token.RefreshToken != _account.Secret)
+                    {
+                        _account.Secret = token.RefreshToken;
+                        if (_onAccountChanged != null) _onAccountChanged(_account);
+                    }
+
+                    _token = token;
                 }
 
-                _token = token;
+                var accessToken = token.AccessToken;
+                if (!string.IsNullOrEmpty(accessToken))
+                {
+                    request.Headers.Add("Authorization", new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, accessToken).ToString());
+                }
             }
-
-            var accessToken = token.AccessToken;
-            if (!string.IsNullOrEmpty(accessToken))
+            finally
             {
-                request.Headers.Add("Authorization", new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, accessToken).ToString());
+                _refreshLock.Release();
             }
         }
     }

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveHelper.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveHelper.cs
@@ -70,5 +70,10 @@ namespace KeeAnywhere.StorageProviders.OneDrive
 
             return api;
         }
+
+        public static void InvalidateCache(string accountId)
+        {
+            Cache.Remove(accountId);
+        }
     }
 }

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveHelper.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveHelper.cs
@@ -39,6 +39,10 @@ namespace KeeAnywhere.StorageProviders.OneDrive
 
         private static readonly IDictionary<string, GraphServiceClient> Cache = new Dictionary<string, GraphServiceClient>();
 
+        // Invoked by OneDriveAuthenticationProvider after a refresh-token
+        // rotation. Wired by KeeAnywhereExt to ConfigurationService.Save().
+        public static Action<AccountConfiguration> OnAccountChanged;
+
         public static OidcFlow CreateOidcFlow()
         {
             return new OidcFlow(StorageType.OneDrive, Authority, OneDriveClientId, null, Scopes)
@@ -51,7 +55,7 @@ namespace KeeAnywhere.StorageProviders.OneDrive
         {
             if (Cache.ContainsKey(account.Id)) return Cache[account.Id];
 
-            var authProvider = new OneDriveAuthenticationProvider(CreateOidcFlow(), account.Secret);
+            var authProvider = new OneDriveAuthenticationProvider(CreateOidcFlow(), account, OnAccountChanged);
 
             //var httpProvider = new HttpProvider(ProxyTools.CreateHttpClientHandler(), true)
             //{

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveStorageProvider.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveStorageProvider.cs
@@ -7,7 +7,6 @@ using KeeAnywhere.Configuration;
 using Microsoft.Graph;
 using Microsoft.Graph.Drives.Item.Items.Item.Copy;
 using Microsoft.Graph.Models;
-using Microsoft.Graph.Models.ODataErrors;
 
 namespace KeeAnywhere.StorageProviders.OneDrive
 {
@@ -25,20 +24,11 @@ namespace KeeAnywhere.StorageProviders.OneDrive
 
         public async Task<Stream> Load(string path)
         {
-            try
-            {
-                return await (await _api.DriveItemFromPathAsync(path)).Content.GetAsync();
-            }
-            catch (ODataError ex)
-            {
-                // Microsoft.Graph 5.x ODataError has an empty Message;
-                // surface the real status and OData code/message so KeePass
-                // doesn't fall back to "An unknown error occurred."
-                var code = ex.Error != null ? ex.Error.Code : "(no code)";
-                var msg = ex.Error != null ? ex.Error.Message : "(no message)";
-                throw new InvalidOperationException(
-                    "OneDrive Load HTTP " + ex.ResponseStatusCode + " (" + code + "): " + msg + " [" + path + "]", ex);
-            }
+            var stream = await (await _api.DriveItemFromPathAsync(path))
+                                    .Content
+                                    .GetAsync();
+
+            return stream;
         }
 
 

--- a/KeeAnywhere/StorageProviders/OneDrive/OneDriveStorageProvider.cs
+++ b/KeeAnywhere/StorageProviders/OneDrive/OneDriveStorageProvider.cs
@@ -7,6 +7,7 @@ using KeeAnywhere.Configuration;
 using Microsoft.Graph;
 using Microsoft.Graph.Drives.Item.Items.Item.Copy;
 using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 
 namespace KeeAnywhere.StorageProviders.OneDrive
 {
@@ -24,11 +25,20 @@ namespace KeeAnywhere.StorageProviders.OneDrive
 
         public async Task<Stream> Load(string path)
         {
-            var stream = await (await _api.DriveItemFromPathAsync(path))
-                                    .Content
-                                    .GetAsync();
-
-            return stream;
+            try
+            {
+                return await (await _api.DriveItemFromPathAsync(path)).Content.GetAsync();
+            }
+            catch (ODataError ex)
+            {
+                // Microsoft.Graph 5.x ODataError has an empty Message;
+                // surface the real status and OData code/message so KeePass
+                // doesn't fall back to "An unknown error occurred."
+                var code = ex.Error != null ? ex.Error.Code : "(no code)";
+                var msg = ex.Error != null ? ex.Error.Message : "(no message)";
+                throw new InvalidOperationException(
+                    "OneDrive Load HTTP " + ex.ResponseStatusCode + " (" + code + "): " + msg + " [" + path + "]", ex);
+            }
         }
 
 

--- a/KeeAnywhere/StorageProviders/StorageDescriptor.cs
+++ b/KeeAnywhere/StorageProviders/StorageDescriptor.cs
@@ -6,7 +6,7 @@ namespace KeeAnywhere.StorageProviders
 {
     public class StorageDescriptor
     {
-        public StorageDescriptor(StorageType type, string friendlyName, string scheme, Func<AccountConfiguration, IStorageProvider> providerFactory, Func<IStorageConfigurator> configuratorFactory, Image smallImage)
+        public StorageDescriptor(StorageType type, string friendlyName, string scheme, Func<AccountConfiguration, IStorageProvider> providerFactory, Func<IStorageConfigurator> configuratorFactory, Image smallImage, Action<string> invalidateCacheAction = null)
         {
             Type = type;
             FriendlyName = friendlyName;
@@ -14,6 +14,7 @@ namespace KeeAnywhere.StorageProviders
             ProviderFactory = providerFactory;
             ConfiguratorFactory = configuratorFactory;
             SmallImage = smallImage;
+            InvalidateCacheAction = invalidateCacheAction;
         }
 
         public StorageType Type { get; private set; }
@@ -22,5 +23,6 @@ namespace KeeAnywhere.StorageProviders
         public Func<AccountConfiguration, IStorageProvider> ProviderFactory { get; private set; }
         public Func<IStorageConfigurator> ConfiguratorFactory { get; private set; }
         public Image SmallImage { get; private set; }
+        public Action<string> InvalidateCacheAction { get; private set; }
     }
 }

--- a/KeeAnywhere/StorageProviders/StorageRegistry.cs
+++ b/KeeAnywhere/StorageProviders/StorageRegistry.cs
@@ -23,14 +23,14 @@ namespace KeeAnywhere.StorageProviders
             d.Add(new StorageDescriptor(StorageType.AmazonS3, "Amazon S3", "s3", account => new AmazonS3StorageProvider(account), () => new AmazonS3StorageConfigurator(), PluginResources.AmazonS3_16x16));
             d.Add(new StorageDescriptor(StorageType.AzureBlob, "Azure Blob Storage", "azureblob", account => new AzureBlobStorageProvider(account), () => new AzureStorageConfigurator(StorageType.AzureBlob), PluginResources.Azure_16x16));
             d.Add(new StorageDescriptor(StorageType.AzureFile, "Azure File Storage", "azurefile", account => new AzureFileStorageProvider(account), () => new AzureStorageConfigurator(StorageType.AzureFile), PluginResources.Azure_16x16));
-            if (!isUnix) d.Add(new StorageDescriptor(StorageType.Box, "Box", "box", account => new BoxStorageProvider(account), () => new BoxStorageConfigurator(), PluginResources.Box_16x16));
+            if (!isUnix) d.Add(new StorageDescriptor(StorageType.Box, "Box", "box", account => new BoxStorageProvider(account), () => new BoxStorageConfigurator(), PluginResources.Box_16x16, BoxHelper.InvalidateCache));
             d.Add(new StorageDescriptor(StorageType.Dropbox, "Dropbox", "dropbox", account => new DropboxStorageProvider(account), () => new DropboxStorageConfigurator(false), PluginResources.Dropbox_16x16));
             d.Add(new StorageDescriptor(StorageType.DropboxRestricted, "Dropbox (restricted)", "dropbox-r", account => new DropboxStorageProvider(account), () => new DropboxStorageConfigurator(true), PluginResources.Dropbox_16x16));
             d.Add(new StorageDescriptor(StorageType.GoogleCloudStorage, "Google Cloud Storage", "gs", account => new GoogleCloudStorageProvider(account), () => new GoogleCloudStorageConfigurator(), PluginResources.GoogleCloudStorage_16x16));
             d.Add(new StorageDescriptor(StorageType.GoogleDrive, "Google Drive", "gdrive", account => new GoogleDriveStorageProvider(account), () => new GoogleDriveStorageConfigurator(false), PluginResources.GoogleDrive_16x16));
             d.Add(new StorageDescriptor(StorageType.GoogleDriveRestricted, "Google Drive (restricted)", "gdrive-r", account => new GoogleDriveStorageProvider(account), () => new GoogleDriveStorageConfigurator(true), PluginResources.GoogleDrive_16x16));
             d.Add(new StorageDescriptor(StorageType.HiDrive, "HiDrive", "hidrive", account => new HiDriveStorageProvider(account), () => new HiDriveStorageConfigurator(), PluginResources.HiDrive_16x16));
-            d.Add(new StorageDescriptor(StorageType.OneDrive, "OneDrive", "onedrive", account => new OneDriveStorageProvider(account), () => new OneDriveStorageConfigurator(), PluginResources.OneDrive_16x16));
+            d.Add(new StorageDescriptor(StorageType.OneDrive, "OneDrive", "onedrive", account => new OneDriveStorageProvider(account), () => new OneDriveStorageConfigurator(), PluginResources.OneDrive_16x16, OneDriveHelper.InvalidateCache));
 
             Descriptors = d.ToArray();
         }

--- a/KeeAnywhere/UIService.cs
+++ b/KeeAnywhere/UIService.cs
@@ -52,6 +52,7 @@ namespace KeeAnywhere
 
             //existingAccount.Name = newAccount.Name;
             existingAccount.Secret = newAccount.Secret;
+            InvalidateProviderCache(existingAccount);
 
             return existingAccount;
         }
@@ -91,8 +92,16 @@ namespace KeeAnywhere
             else
             {
                 account.Secret = newAccount.Secret;
+                InvalidateProviderCache(account);
                 MessageService.ShowInfo("Re-Authorization succeeded!");
             }
+        }
+
+        private static void InvalidateProviderCache(AccountConfiguration account)
+        {
+            var descriptor = StorageRegistry.Descriptors.FirstOrDefault(_ => _.Type == account.Type);
+            if (descriptor != null && descriptor.InvalidateCacheAction != null)
+                descriptor.InvalidateCacheAction(account.Id);
         }
 
         public void ShowDonationDialog()


### PR DESCRIPTION
Partial fix for #468 — symptoms there were caused by several distinct bugs:

 - Auth and cloud-sync failures were surfacing as "An unknown error occurred" in KeePass because the underlying exceptions had empty Message properties. Real status codes and AADSTS descriptions now reach the user.
 - Per-account API clients were cached but not invalidated after re-auth, so re-authorized accounts kept using the previous (now-revoked) refresh token until KeePass restart.
 - Microsoft rotates the refresh token on every refresh; the new value wasn't being written back to account.Secret, so the stored token went stale within minutes of the first OneDrive call in a session and most subsequent KeePass launches failed with invalid_grant.
 - Token-expiry check used DateTime.Now but the SDK exposes AccessTokenExpiration in UTC, forcing unnecessary refreshes (and on the wrong direction of TZ offset, using stale tokens past their real UTC expiry).
 - OneDrive content URLs of the form /items/{id}:/<path>:/content 404 on personal accounts, and the SDK's itemWithPath() helper URL-encodes / so multi-segment paths can't be addressed through it. Path resolution now walks Items[id].Children segment by segment (with
 @odata.nextLink pagination so folders with >200 entries don't silently miss).
- The system-browser OAuth listener now reads the callback from either the query string or a form_post body — Microsoft's v2.0 endpoint uses the latter, which was silently failing as "Empty response".

What isn't fixed:
-  The Google Drive symptoms haven't been verified because I can't reproduce them (I don't use GDrive), but the same error - surfacing improvements - were applied there so a future bug report will carry the real Graph error rather than a silent null.
- If/when a token expires, there is no UI to re-authenticate. The cloud connection must be removed and re-added.

Disclaimer: Claude Code was used to help with this PR