### PR TITLE
Fix plgx compilation issue caused by version drift.

### DIFF
--- a/KeeAnywhere/KeeAnywhere.csproj
+++ b/KeeAnywhere/KeeAnywhere.csproj
@@ -245,7 +245,6 @@
     <Reference Include="Std.UriTemplate, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c118b0afb4598f9a, processorArchitecture=MSIL">
       <HintPath>..\packages\Std.UriTemplate.1.0.1\lib\netstandard2.0\Std.UriTemplate.dll</HintPath>
     </Reference>
-    <Reference Include="netstandard" />
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>

--- a/KeeAnywhere/KeeAnywhere.csproj
+++ b/KeeAnywhere/KeeAnywhere.csproj
@@ -286,11 +286,7 @@
       <HintPath>..\packages\System.Memory.Data.8.0.0\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
-      <Private>True</Private>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>

--- a/KeeAnywhere/KeeAnywhere.csproj
+++ b/KeeAnywhere/KeeAnywhere.csproj
@@ -245,6 +245,7 @@
     <Reference Include="Std.UriTemplate, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c118b0afb4598f9a, processorArchitecture=MSIL">
       <HintPath>..\packages\Std.UriTemplate.1.0.1\lib\netstandard2.0\Std.UriTemplate.dll</HintPath>
     </Reference>
+    <Reference Include="netstandard" />
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>

--- a/KeeAnywhere/KeeAnywhere.csproj
+++ b/KeeAnywhere/KeeAnywhere.csproj
@@ -64,11 +64,11 @@
     <Reference Include="Dropbox.Api, Version=7.0.0.0, Culture=neutral, PublicKeyToken=310f0e82fbb45d01, processorArchitecture=MSIL">
       <HintPath>..\packages\Dropbox.Api.7.0.0\lib\netstandard2.0\Dropbox.Api.dll</HintPath>
     </Reference>
-    <Reference Include="Google.Api.Gax, Version=4.8.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.4.8.0\lib\net462\Google.Api.Gax.dll</HintPath>
+    <Reference Include="Google.Api.Gax, Version=4.9.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Api.Gax.4.9.0\lib\net462\Google.Api.Gax.dll</HintPath>
     </Reference>
-    <Reference Include="Google.Api.Gax.Rest, Version=4.8.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.Rest.4.8.0\lib\net462\Google.Api.Gax.Rest.dll</HintPath>
+    <Reference Include="Google.Api.Gax.Rest, Version=4.9.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Api.Gax.Rest.4.9.0\lib\net462\Google.Api.Gax.Rest.dll</HintPath>
     </Reference>
     <Reference Include="Google.Apis, Version=1.68.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Apis.1.68.0\lib\net462\Google.Apis.dll</HintPath>
@@ -82,11 +82,11 @@
     <Reference Include="Google.Apis.Drive.v3, Version=1.68.0.3428, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Apis.Drive.v3.1.68.0.3428\lib\net462\Google.Apis.Drive.v3.dll</HintPath>
     </Reference>
-    <Reference Include="Google.Apis.Storage.v1, Version=1.68.0.3431, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Storage.v1.1.68.0.3431\lib\net462\Google.Apis.Storage.v1.dll</HintPath>
+    <Reference Include="Google.Apis.Storage.v1, Version=1.68.0.3604, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Storage.v1.1.68.0.3604\lib\net462\Google.Apis.Storage.v1.dll</HintPath>
     </Reference>
-    <Reference Include="Google.Cloud.Storage.V1, Version=4.10.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Storage.V1.4.10.0\lib\net462\Google.Cloud.Storage.V1.dll</HintPath>
+    <Reference Include="Google.Cloud.Storage.V1, Version=4.11.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Cloud.Storage.V1.4.11.0\lib\net462\Google.Cloud.Storage.V1.dll</HintPath>
     </Reference>
     <Reference Include="IdentityModel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=e7877f4675df049f, processorArchitecture=MSIL">
       <HintPath>..\packages\IdentityModel.7.0.0\lib\net472\IdentityModel.dll</HintPath>

--- a/KeeAnywhere/packages.config
+++ b/KeeAnywhere/packages.config
@@ -81,7 +81,6 @@
   <package id="System.Management" version="8.0.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Memory.Data" version="8.0.0" targetFramework="net48" />
-  <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
   <package id="System.Net.Http.WinHttpHandler" version="8.0.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Private.Uri" version="4.3.2" targetFramework="net48" />

--- a/KeeAnywhere/packages.config
+++ b/KeeAnywhere/packages.config
@@ -9,14 +9,14 @@
   <package id="Box.V2" version="5.7.0" targetFramework="net48" />
   <package id="CredentialManagement" version="1.0.2" targetFramework="net48" />
   <package id="Dropbox.Api" version="7.0.0" targetFramework="net48" />
-  <package id="Google.Api.Gax" version="4.8.0" targetFramework="net48" />
-  <package id="Google.Api.Gax.Rest" version="4.8.0" targetFramework="net48" />
+  <package id="Google.Api.Gax" version="4.9.0" targetFramework="net48" />
+  <package id="Google.Api.Gax.Rest" version="4.9.0" targetFramework="net48" />
   <package id="Google.Apis" version="1.68.0" targetFramework="net48" />
   <package id="Google.Apis.Auth" version="1.68.0" targetFramework="net48" />
   <package id="Google.Apis.Core" version="1.68.0" targetFramework="net48" />
   <package id="Google.Apis.Drive.v3" version="1.68.0.3428" targetFramework="net48" />
-  <package id="Google.Apis.Storage.v1" version="1.68.0.3431" targetFramework="net48" />
-  <package id="Google.Cloud.Storage.V1" version="4.10.0" targetFramework="net48" />
+  <package id="Google.Apis.Storage.v1" version="1.68.0.3604" targetFramework="net48" />
+  <package id="Google.Cloud.Storage.V1" version="4.11.0" targetFramework="net48" />
   <package id="IdentityModel" version="7.0.0" targetFramework="net48" />
   <package id="IdentityModel.OidcClient" version="6.0.0" targetFramework="net48" />
   <package id="Kyrodan.HiDriveSDK" version="0.2.0" targetFramework="net48" />

--- a/test-plgx.ps1
+++ b/test-plgx.ps1
@@ -1,0 +1,120 @@
+[CmdletBinding()]
+param(
+    [string]$KeePassDir,
+    [ValidateSet("Release", "Debug")]
+    [string]$Configuration = "Release",
+    [switch]$Cleanup
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = $PSScriptRoot
+Set-Location $repoRoot
+
+# 1. Locate portable KeePass (or ask).
+if (-not $KeePassDir) {
+    $defaultDir = Join-Path (Split-Path $repoRoot -Parent) "KeePass-2.61"
+    if (Test-Path (Join-Path $defaultDir "KeePass.exe")) {
+        $KeePassDir = $defaultDir
+    }
+}
+
+while (-not $KeePassDir -or -not (Test-Path (Join-Path $KeePassDir "KeePass.exe"))) {
+    if ($KeePassDir) {
+        Write-Host "KeePass.exe not found in '$KeePassDir'." -ForegroundColor Yellow
+    } else {
+        Write-Host "Portable KeePass not found." -ForegroundColor Yellow
+        Write-Host "Download the portable ZIP from https://keepass.info/download.html and extract it anywhere."
+    }
+    $KeePassDir = Read-Host "Path to your portable KeePass folder"
+    if ([string]::IsNullOrWhiteSpace($KeePassDir)) { throw "Cancelled." }
+}
+
+$kpExe = Join-Path $KeePassDir "KeePass.exe"
+$pluginsDir = Join-Path $KeePassDir "Plugins"
+if (-not (Test-Path $pluginsDir)) { New-Item -ItemType Directory -Path $pluginsDir | Out-Null }
+
+# 2. Build (Release triggers PlgxTool's AfterBuild target).
+$vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found. Install Visual Studio 2017+ or VS Build Tools." }
+$msbuild = & $vswhere -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+if (-not $msbuild) { throw "MSBuild not found via vswhere." }
+
+Write-Host "Building $Configuration..." -ForegroundColor Cyan
+& (Join-Path $repoRoot "nuget.exe") restore (Join-Path $repoRoot "KeeAnywhere.sln") | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "nuget restore failed." }
+& $msbuild (Join-Path $repoRoot "KeeAnywhere\KeeAnywhere.csproj") "/p:Configuration=$Configuration" "/t:Clean,Build" "/nologo" "/v:q" | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "Build failed." }
+
+$plgx = Join-Path $repoRoot "KeeAnywhere\bin\$Configuration\KeeAnywhere.plgx"
+if (-not (Test-Path $plgx)) { throw "$plgx wasn't produced. PlgxTool only fires on Release." }
+Write-Host "Built: $plgx" -ForegroundColor Green
+
+# 3. Make sure no KeePass instance is holding the Plugins folder.
+& $kpExe --exit-all 2>&1 | Out-Null
+Get-Process KeePass -ErrorAction SilentlyContinue | Wait-Process -Timeout 5 -ErrorAction SilentlyContinue
+
+# 4. Optional cache reset. KeePass keeps a per-plgx-hash compiled DLL under
+#    %LOCALAPPDATA%\KeePass\PluginCache; a stale entry can mask a real failure.
+#    Off by default — pass -Cleanup to wipe it (and the deployed plgx).
+if ($Cleanup) {
+    Write-Host "Cleanup: wiping PluginCache and prior plgx deployment." -ForegroundColor Yellow
+    $cacheDir = Join-Path $env:LOCALAPPDATA "KeePass\PluginCache"
+    if (Test-Path $cacheDir) { Remove-Item $cacheDir -Recurse -Force -ErrorAction SilentlyContinue }
+    Get-ChildItem $pluginsDir -Filter "KeeAnywhere*" -File -ErrorAction SilentlyContinue | Remove-Item -Force
+}
+
+Copy-Item $plgx $pluginsDir -Force
+Write-Host "Deployed to $pluginsDir" -ForegroundColor Green
+
+# 5. Run KeePass with --debug so PlgxPlugin.SaveCompilerResults writes the
+#    compile log to %TEMP%\tmpXXXX.tmp on failure.
+$cutoff = Get-Date
+Write-Host ""
+Write-Host "Launching KeePass --debug. Close it (and dismiss any error dialogs) to continue." -ForegroundColor Yellow
+& $kpExe --debug | Out-Null
+Get-Process KeePass -ErrorAction SilentlyContinue | Wait-Process -Timeout 5 -ErrorAction SilentlyContinue
+
+# 6. Report.
+$logs = Get-ChildItem $env:TEMP -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.LastWriteTime -gt $cutoff -and $_.Length -gt 0 -and $_.Extension -eq ".tmp" } |
+    Sort-Object LastWriteTime -Descending
+
+$compileLog = $null
+foreach ($l in $logs) {
+    $head = Get-Content $l.FullName -TotalCount 5 -ErrorAction SilentlyContinue
+    if ($head -match "Compiler|csc\.exe|error CS") {
+        $compileLog = $l
+        break
+    }
+}
+
+Write-Host ""
+if ($compileLog) {
+    Write-Host "=== plgx FAILED to compile ===" -ForegroundColor Red
+    $errors = Get-Content $compileLog.FullName | Select-String "error CS\d" | Select-Object -ExpandProperty Line
+    if ($errors) {
+        Write-Host "Compiler errors:" -ForegroundColor Red
+        $errors | Select-Object -First 20 | ForEach-Object { Write-Host "  $_" }
+        if ($errors.Count -gt 20) { Write-Host "  ... ($($errors.Count - 20) more)" }
+    }
+    Write-Host ""
+    Write-Host "Full log: $($compileLog.FullName)" -ForegroundColor DarkGray
+    exit 1
+}
+
+$compiled = Get-ChildItem (Join-Path $env:LOCALAPPDATA "KeePass\PluginCache") -Filter "KeeAnywhere.dll" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($compiled) {
+    Write-Host "=== plgx compiled OK ===" -ForegroundColor Green
+    Write-Host "Compiled assembly: $($compiled.FullName)" -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "Note: a clean compile doesn't guarantee runtime load — KeePass's compatibility check"
+    Write-Host "(PluginManager.CheckCompatibility) can still reject the assembly for transitive version"
+    Write-Host "mismatches. If you saw a 'Could not load file or assembly' dialog, the plgx compiled"
+    Write-Host "but failed the post-compile binding check."
+    exit 0
+}
+
+Write-Host "=== inconclusive ===" -ForegroundColor Yellow
+Write-Host "No compiler error log in TEMP and no compiled assembly in PluginCache."
+Write-Host "KeePass may not have attempted to load the plgx (e.g. closed before reaching it)."
+exit 2


### PR DESCRIPTION
plgx loading has been broken since the June 2024 dependency bump (issue #485 )

  The plgx file works by shipping the project's source code plus all referenced DLLs; KeePass extracts everything to a temp folder and runs csc.exe against it on first load. That compile pass only sees what PlgxTool bundled — it does not read app.config, so the binding redirects that normally smooth over transitive dependency version mismatches at runtime are not applied.
  Since c750b72 ("Updated dependencies") this has been a problem for several reasons that all reduce to the same shape:

  - System.Net.Http is bundled at version 4.1.1.3 (from System.Net.Http 4.3.4's lib/net46), but Microsoft.Graph.Core 3.1.12 was compiled against 4.2.0.0 — csc raises CS1705. .NET Framework 4.7.2+ already includes 4.2.0.0 in the reference assemblies; the NuGet package isn't needed for net48.
  - Google.Cloud.Storage.V1 4.10.0 was compiled against Google.Apis.Storage.v1 1.67.0.3365 while the project ships 1.68.0.3431. Same metadata-level mismatch: at runtime an app.config redirect would handle it, at plgx-compile time it doesn't and csc errors.

  What this PR changes

  - Removes the System.Net.Http 4.3.4 NuGet package and replaces the versioned reference with a bare <Reference Include="System.Net.Http" />. csc then resolves to the framework's 4.2.0.0, which is what Microsoft.Graph.Core expects.
  - Bumps Google.Cloud.Storage.V1 4.10 → 4.11 (and the cascade: Google.Apis.Storage.v1 1.68.0.3431 → 1.68.0.3604, Google.Api.Gax and Google.Api.Gax.Rest 4.8 → 4.9) so every package's compile-time metadata agrees on the same 1.68.x baseline. No binding redirects required.
  - Adds test-plgx.ps1, a script that builds Release, deploys the plgx to a portable KeePass install, runs KeePass --debug, and reports whether the plgx compiled cleanly. Default behavior is non-destructive; pass -Cleanup to also wipe %LOCALAPPDATA%\KeePass\PluginCache (useful when iterating on dependency fixes).


Edit: netstandard was actually already referenced. my mistake